### PR TITLE
refactor : SeatStatus 엔티티명 변경

### DIFF
--- a/src/main/java/org/example/siljeun/domain/reservation/entity/Reservation.java
+++ b/src/main/java/org/example/siljeun/domain/reservation/entity/Reservation.java
@@ -14,7 +14,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.example.siljeun.domain.seat.entity.SeatStatus;
+import org.example.siljeun.domain.seat.entity.SeatScheduleInfo;
 import org.example.siljeun.domain.user.entity.User;
 import org.springframework.data.annotation.CreatedDate;
 
@@ -33,8 +33,8 @@ public class Reservation {
   private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "seat_status_id", nullable = false)
-  private SeatStatus seatStatus;
+  @JoinColumn(name = "seat_schedule_info_id", nullable = false)
+  private SeatScheduleInfo seatScheduleInfo;
 
   @Column(nullable = false)
   private int price;

--- a/src/main/java/org/example/siljeun/domain/seat/entity/SeatScheduleInfo.java
+++ b/src/main/java/org/example/siljeun/domain/seat/entity/SeatScheduleInfo.java
@@ -12,15 +12,15 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.siljeun.domain.schedule.entity.Schedule;
-import org.example.siljeun.domain.seat.enums.SeatReserveStatus;
+import org.example.siljeun.domain.seat.enums.SeatStatus;
 import org.example.siljeun.global.entity.BaseEntity;
 
 @Entity
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "seat_status")
-public class SeatStatus extends BaseEntity {
+@Table(name = "seat_schedule_info")
+public class SeatScheduleInfo extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,11 +32,11 @@ public class SeatStatus extends BaseEntity {
 
   //회차 정보
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "schedule", nullable = false)
+  @JoinColumn(name = "schedule_id", nullable = false)
   private Schedule schedule;
 
   //상태 (확장성을 위해 우선 enum으로 설정해놓음)
-  private SeatReserveStatus status;
+  private SeatStatus status;
 
   //임시로 String으로 설정
   private String grade;

--- a/src/main/java/org/example/siljeun/domain/seat/enums/SeatStatus.java
+++ b/src/main/java/org/example/siljeun/domain/seat/enums/SeatStatus.java
@@ -1,6 +1,6 @@
 package org.example.siljeun.domain.seat.enums;
 
-public enum SeatReserveStatus {
+public enum SeatStatus {
   AVALIABLE,
   UNAVALIABLE
 }


### PR DESCRIPTION
## 🔎 작업 내용

SeatStatus 엔티티 이름을 SeatScheduleInfo 으로 변경함

---

## 🛠️ 변경 사항

- SeatStatus 엔티티와 이를 사용하던 부분을 SeatScheduleInfo로 변경
- Enum 타입의 SeatReserveStatus를 SeatStatus로 변경
- JoinColumn(name = "schedule")을 schedule_id로 변경

---

## 🧩 트러블 슈팅

---

## 🧯 해결해야 할 문제

---

## 📌 참고 사항


---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인