### PR TITLE
feat(concert): implement concert API and add schedule/venue DTOs

### DIFF
--- a/src/main/java/org/example/siljeun/domain/concert/controller/ConcertController.java
+++ b/src/main/java/org/example/siljeun/domain/concert/controller/ConcertController.java
@@ -1,0 +1,65 @@
+package org.example.siljeun.domain.concert.controller;
+
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.example.siljeun.domain.concert.dto.request.ConcertCreateRequest;
+import org.example.siljeun.domain.concert.dto.request.ConcertUpdateRequest;
+import org.example.siljeun.domain.concert.dto.response.ConcertDetailResponse;
+import org.example.siljeun.domain.concert.dto.response.ConcertSimpleResponse;
+import org.example.siljeun.domain.concert.service.ConcertService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/concerts")
+public class ConcertController {
+
+  private final ConcertService concertService;
+
+  @PostMapping
+  public ResponseEntity<Long> createConcert(
+      @RequestBody @Valid ConcertCreateRequest request,
+      @RequestAttribute("userId") Long userId
+  ) {
+    Long concertId = concertService.createConcert(request, userId);
+    return ResponseEntity.created(URI.create("/concerts" + concertId)).body(concertId);
+  }
+
+  @PutMapping("/{concertId}")
+  public ResponseEntity<Void> updateConcert(
+      @PathVariable Long concertId,
+      @RequestBody @Valid ConcertUpdateRequest request
+  ) {
+    concertService.updateConcert(concertId, request);
+    return ResponseEntity.ok().build();
+  }
+
+  @DeleteMapping("/{concertId}")
+  public ResponseEntity<Void> deleteConcert(@PathVariable Long concertId) {
+    concertService.deleteConcert(concertId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping
+  public ResponseEntity<List<ConcertSimpleResponse>> getConcertList() {
+    List<ConcertSimpleResponse> concerts = concertService.getConcertList();
+    return ResponseEntity.ok(concerts);
+  }
+
+  @GetMapping("/{concertId}")
+  public ResponseEntity<ConcertDetailResponse> getConcertDetail(@PathVariable Long concertId) {
+    ConcertDetailResponse response = concertService.getConcertDetail(concertId);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/org/example/siljeun/domain/concert/dto/request/ConcertCreateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/concert/dto/request/ConcertCreateRequest.java
@@ -1,0 +1,15 @@
+package org.example.siljeun.domain.concert.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.siljeun.domain.concert.entity.ConcertCategory;
+
+public record ConcertCreateRequest(@NotBlank
+                                   String title,
+                                   String description,
+                                   @NotNull
+                                   ConcertCategory category,
+                                   @NotNull Long venuId,
+                                   Integer cancleCharge) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/concert/dto/request/ConcertUpdateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/concert/dto/request/ConcertUpdateRequest.java
@@ -1,0 +1,15 @@
+package org.example.siljeun.domain.concert.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.siljeun.domain.concert.entity.ConcertCategory;
+
+public record ConcertUpdateRequest(
+    @NotBlank String title,
+    String description,
+    @NotNull ConcertCategory category,
+    @NotNull Long venueId,
+    Integer cancelCharge
+) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/concert/dto/response/ConcertDetailResponse.java
+++ b/src/main/java/org/example/siljeun/domain/concert/dto/response/ConcertDetailResponse.java
@@ -1,0 +1,28 @@
+package org.example.siljeun.domain.concert.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import org.example.siljeun.domain.concert.entity.ConcertCategory;
+import org.example.siljeun.domain.schedule.dto.response.ScheduleSimpleResponse;
+import org.example.siljeun.domain.venue.dto.response.VenueSimpleResponse;
+
+@Getter
+public class ConcertDetailResponse {
+
+  private Long id;
+  private String title;
+  private String description;
+  private ConcertCategory category;
+  private VenueSimpleResponse venue;
+  private List<ScheduleSimpleResponse> schedules;
+
+  public ConcertDetailResponse(Long id, String title, String description, ConcertCategory category,
+      VenueSimpleResponse venue, List<ScheduleSimpleResponse> schedules) {
+    this.id = id;
+    this.title = title;
+    this.description = description;
+    this.category = category;
+    this.venue = venue;
+    this.schedules = schedules;
+  }
+}

--- a/src/main/java/org/example/siljeun/domain/concert/dto/response/ConcertSimpleResponse.java
+++ b/src/main/java/org/example/siljeun/domain/concert/dto/response/ConcertSimpleResponse.java
@@ -1,0 +1,10 @@
+package org.example.siljeun.domain.concert.dto.response;
+
+public record ConcertSimpleResponse(
+    Long id,
+    String title,
+    String venueName,
+    String category
+) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/concert/entity/Concert.java
+++ b/src/main/java/org/example/siljeun/domain/concert/entity/Concert.java
@@ -11,13 +11,17 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.siljeun.domain.venue.entity.Venue;
 import org.example.siljeun.global.entity.BaseEntity;
 
 @Entity
 @Getter
 @Table(name = "concert")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Concert extends BaseEntity {
 
   @Id
@@ -36,6 +40,24 @@ public class Concert extends BaseEntity {
   @JoinColumn(name = "venue_id", nullable = false)
   private Venue venue;
 
-  private int cancel_charge;
+  private int cancelCharge;
 
+  @Builder
+  public Concert(String title, String description, ConcertCategory category, Venue venue,
+      int cancelCharge) {
+    this.title = title;
+    this.description = description;
+    this.category = category;
+    this.venue = venue;
+    this.cancelCharge = cancelCharge;
+  }
+
+  public void update(String title, String description, ConcertCategory category, Venue venue,
+      int cancelCharge) {
+    this.title = title;
+    this.description = description;
+    this.category = category;
+    this.venue = venue;
+    this.cancelCharge = cancelCharge;
+  }
 }

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertService.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertService.java
@@ -1,0 +1,21 @@
+package org.example.siljeun.domain.concert.service;
+
+import java.util.List;
+import org.example.siljeun.domain.concert.dto.request.ConcertCreateRequest;
+import org.example.siljeun.domain.concert.dto.request.ConcertUpdateRequest;
+import org.example.siljeun.domain.concert.dto.response.ConcertDetailResponse;
+import org.example.siljeun.domain.concert.dto.response.ConcertSimpleResponse;
+
+public interface ConcertService {
+
+  Long createConcert(ConcertCreateRequest request, Long userId);
+
+  void updateConcert(Long concertId, ConcertUpdateRequest request);
+
+  void deleteConcert(Long concertId);
+
+  List<ConcertSimpleResponse> getConcertList();
+
+  ConcertDetailResponse getConcertDetail(Long concertId);
+
+}

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertServiceImpl.java
@@ -1,0 +1,114 @@
+package org.example.siljeun.domain.concert.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.example.siljeun.domain.concert.dto.request.ConcertCreateRequest;
+import org.example.siljeun.domain.concert.dto.request.ConcertUpdateRequest;
+import org.example.siljeun.domain.concert.dto.response.ConcertDetailResponse;
+import org.example.siljeun.domain.concert.dto.response.ConcertSimpleResponse;
+import org.example.siljeun.domain.concert.entity.Concert;
+import org.example.siljeun.domain.concert.repository.ConcertRepository;
+import org.example.siljeun.domain.schedule.dto.response.ScheduleSimpleResponse;
+import org.example.siljeun.domain.schedule.repository.ScheduleRepository;
+import org.example.siljeun.domain.user.repository.UserRepository;
+import org.example.siljeun.domain.venue.dto.response.VenueSimpleResponse;
+import org.example.siljeun.domain.venue.entity.Venue;
+import org.example.siljeun.domain.venue.repository.VenueRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConcertServiceImpl implements ConcertService {
+
+  private final ConcertRepository concertRepository;
+  private final VenueRepository venueRepository;
+  private final UserRepository userRepository;
+  private final ScheduleRepository scheduleRepository;
+
+
+  @Override
+  @Transactional
+  public Long createConcert(ConcertCreateRequest request, Long userId) {
+    Venue venue = venueRepository.findById(request.venuId())
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 공연장입니다."));
+
+    Concert concert = Concert.builder()
+        .title(request.title())
+        .description(request.description())
+        .category(request.category())
+        .venue(venue)
+        .cancelCharge(request.cancleCharge())
+        .build();
+
+    return concertRepository.save(concert).getId();
+  }
+
+  @Override
+  @Transactional
+  public void updateConcert(Long concertId, ConcertUpdateRequest request) {
+    Concert concert = concertRepository.findById(concertId)
+        .orElseThrow(() -> new EntityNotFoundException("해당 공연이 존재하지 않습니다."));
+
+    Venue venue = venueRepository.findById(request.venueId())
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 공연장입니다."));
+
+    concert.update(
+        request.title(),
+        request.description(),
+        request.category(),
+        venue,
+        request.cancelCharge()
+    );
+  }
+
+  @Override
+  @Transactional
+  public void deleteConcert(Long concertId) {
+    concertRepository.deleteById(concertId);
+  }
+
+  @Override
+  public List<ConcertSimpleResponse> getConcertList() {
+    return concertRepository.findAll().stream()
+        .map(concert -> new ConcertSimpleResponse(
+            concert.getId(),
+            concert.getTitle(),
+            concert.getVenue().getName(),
+            concert.getCategory().name()
+        ))
+        .toList();
+  }
+
+  @Override
+  public ConcertDetailResponse getConcertDetail(Long concertId) {
+    Concert concert = concertRepository.findById(concertId)
+        .orElseThrow(() -> new EntityNotFoundException("해당 공연이 존재하지 않습니다."));
+
+    VenueSimpleResponse venueResponse = new VenueSimpleResponse(
+        concert.getVenue().getId(),
+        concert.getVenue().getName(),
+        concert.getVenue().getLocation(),
+        concert.getVenue().getSeatCapacity()
+    );
+
+    List<ScheduleSimpleResponse> schedules = scheduleRepository.findByConcertId(concertId).stream()
+        .map(schedule -> new ScheduleSimpleResponse(
+            schedule.getId(),
+            schedule.getStartTime(),
+            schedule.getTicketingStartTime()
+        ))
+        .toList();
+
+    return new ConcertDetailResponse(
+        concert.getId(),
+        concert.getTitle(),
+        concert.getDescription(),
+        concert.getCategory(),
+        venueResponse,
+        schedules
+    );
+  }
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/dto/request/ScheduleCreateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/dto/request/ScheduleCreateRequest.java
@@ -1,0 +1,12 @@
+package org.example.siljeun.domain.schedule.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record ScheduleCreateRequest(
+    @NotNull LocalDateTime startTime,
+    @NotNull LocalDateTime ticketingStartTime,
+    @NotNull Long concertId
+) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/dto/response/ScheduleSimpleResponse.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/dto/response/ScheduleSimpleResponse.java
@@ -1,0 +1,11 @@
+package org.example.siljeun.domain.schedule.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ScheduleSimpleResponse(
+    Long id,
+    LocalDateTime startTime,
+    LocalDateTime ticketingStartTime
+) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/repository/ScheduleRepository.java
@@ -1,8 +1,10 @@
 package org.example.siljeun.domain.schedule.repository;
 
+import java.util.List;
 import org.example.siljeun.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
+  List<Schedule> findByConcertId(Long concertId);
 }

--- a/src/main/java/org/example/siljeun/domain/venue/dto/request/VenueCreateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/venue/dto/request/VenueCreateRequest.java
@@ -1,0 +1,12 @@
+package org.example.siljeun.domain.venue.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record VenueCreateRequest(
+    @NotBlank String name,
+    @NotBlank String location,
+    @NotNull Integer seatCapacity
+) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/venue/dto/request/VenueUpdateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/venue/dto/request/VenueUpdateRequest.java
@@ -1,0 +1,11 @@
+package org.example.siljeun.domain.venue.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record VenueUpdateRequest(
+    @NotBlank String name,
+    @NotBlank String location,
+    @NotNull Integer seatCapacity) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/venue/dto/response/VenueSimpleResponse.java
+++ b/src/main/java/org/example/siljeun/domain/venue/dto/response/VenueSimpleResponse.java
@@ -1,0 +1,10 @@
+package org.example.siljeun.domain.venue.dto.response;
+
+public record VenueSimpleResponse(
+    Long id,
+    String name,
+    String location,
+    Integer seatCapacity
+) {
+
+}


### PR DESCRIPTION
---

## 🔎 작업 내용

- Concert 도메인 API 개발
- 관련 Venue/Schedule DTO 정의

---

## 🛠️ 변경 사항

###  ConcertController CRUD 구현 (`/concerts`)
- `POST /api/concerts`: 공연 등록
- `PUT /api/concerts/{id}`: 공연 수정
- `DELETE /api/concerts/{id}`: 공연 삭제
- `GET /api/concerts`: 공연 목록 조회
- `GET /api/concerts/{id}`: 공연 상세 조회 (Schedule 포함)

### ConcertService, ConcertServiceImpl 로직 구현

- `createConcert()`, `updateConcert()`, `deleteConcert()`, `getConcerts()`, `getConcertDetail()` 등 구현
- `ScheduleRepository.findByConcertId()` 추가 (단방향 조회용)

### DTO 정의

- `ConcertCreateRequest`, `ConcertUpdateRequest`
- `ConcertSimpleResponse`, `ConcertDetailResponse`
- `VenueSimpleResponse`, `ScheduleSimpleResponse` (record 기반)

---


## 🧯 해결해야 할 문제

###  공통 응답 포맷 (`ApiResponse<T>`) 미적용

- 현재 모든 API는 `ResponseEntity` 기반으로 개별 응답
- 추후 `success`, `message`, `data` 구조의 공통 포맷으로 통일 예정

###  인증 정보 주입 방식 개선 필요

- 현재는 `@RequestAttribute("userId")` 방식으로 유저 식별자 임시 주입
- 실제 배포 시 JWT 인증 필터 또는 인터셉터로 userId 추출 및 주입 예정

###  예외 처리 보완 필요

- 미인증 사용자 접근 시 예외 처리 미구현
- 전역 예외 핸들러 혹은 인증 예외 핸들러 추가 필요

###  공연 상세 조회 시 스케줄 직접 조회

- `Concert` → `Schedule` 단방향 매핑에 따른 N+1 문제
- 추후 조회 성능 개선을 위해 Fetch Join 또는 QueryDSL 적용

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인