### PR TITLE
feat: implement schedule API

### DIFF
--- a/src/main/java/org/example/siljeun/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/controller/ScheduleController.java
@@ -1,0 +1,46 @@
+package org.example.siljeun.domain.schedule.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.siljeun.domain.schedule.dto.request.ScheduleCreateRequest;
+import org.example.siljeun.domain.schedule.dto.request.ScheduleUpdateRequest;
+import org.example.siljeun.domain.schedule.dto.response.ScheduleSimpleResponse;
+import org.example.siljeun.domain.schedule.service.ScheduleService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/schedules")
+public class ScheduleController {
+
+  private final ScheduleService scheduleService;
+
+  @PostMapping
+  public ResponseEntity<ScheduleSimpleResponse> createSchedule(
+      @RequestBody ScheduleCreateRequest request
+  ) {
+    ScheduleSimpleResponse response = scheduleService.createSchedule(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<ScheduleSimpleResponse> updateSchedule(
+      @PathVariable Long id,
+      @RequestBody ScheduleUpdateRequest request
+  ) {
+    return ResponseEntity.ok(scheduleService.updateSchedule(id, request));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteSchedule(@PathVariable Long id) {
+    scheduleService.deleteSchedule(id);
+    return ResponseEntity.noContent().build();
+  }
+
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/dto/request/ScheduleUpdateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/dto/request/ScheduleUpdateRequest.java
@@ -1,0 +1,10 @@
+package org.example.siljeun.domain.schedule.dto.request;
+
+import java.time.LocalDateTime;
+
+public record ScheduleUpdateRequest(
+    LocalDateTime startTime,
+    LocalDateTime ticketingStartTime
+) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/entity/Schedule.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/entity/Schedule.java
@@ -3,19 +3,21 @@ package org.example.siljeun.domain.schedule.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.siljeun.domain.concert.entity.Concert;
 import org.example.siljeun.global.entity.BaseEntity;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @Table(name = "schedule")
 public class Schedule extends BaseEntity {
 
@@ -32,5 +34,16 @@ public class Schedule extends BaseEntity {
 
   @Column(nullable = false)
   private LocalDateTime ticketingStartTime;
+
+  public Schedule(Concert concert, LocalDateTime startTime, LocalDateTime ticketingStartTime) {
+    this.concert = concert;
+    this.startTime = startTime;
+    this.ticketingStartTime = ticketingStartTime;
+  }
+
+  public void update(LocalDateTime startTime, LocalDateTime ticketingStartTime) {
+    this.startTime = startTime;
+    this.ticketingStartTime = ticketingStartTime;
+  }
 
 }

--- a/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleService.java
@@ -1,0 +1,15 @@
+package org.example.siljeun.domain.schedule.service;
+
+import org.example.siljeun.domain.schedule.dto.request.ScheduleCreateRequest;
+import org.example.siljeun.domain.schedule.dto.request.ScheduleUpdateRequest;
+import org.example.siljeun.domain.schedule.dto.response.ScheduleSimpleResponse;
+
+public interface ScheduleService {
+
+  ScheduleSimpleResponse createSchedule(ScheduleCreateRequest request);
+
+  ScheduleSimpleResponse updateSchedule(Long id, ScheduleUpdateRequest request);
+
+  void deleteSchedule(Long id);
+
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleServiceImpl.java
@@ -1,0 +1,61 @@
+package org.example.siljeun.domain.schedule.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.example.siljeun.domain.concert.entity.Concert;
+import org.example.siljeun.domain.concert.repository.ConcertRepository;
+import org.example.siljeun.domain.schedule.dto.request.ScheduleCreateRequest;
+import org.example.siljeun.domain.schedule.dto.request.ScheduleUpdateRequest;
+import org.example.siljeun.domain.schedule.dto.response.ScheduleSimpleResponse;
+import org.example.siljeun.domain.schedule.entity.Schedule;
+import org.example.siljeun.domain.schedule.repository.ScheduleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScheduleServiceImpl implements ScheduleService {
+
+  private final ScheduleRepository scheduleRepository;
+  private final ConcertRepository concertRepository;
+
+  @Override
+  @Transactional
+  public ScheduleSimpleResponse createSchedule(ScheduleCreateRequest request) {
+    Concert concert = concertRepository.findById(request.concertId())
+        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 공연입니다."));
+
+    Schedule schedule = new Schedule(
+        concert,
+        request.startTime(),
+        request.ticketingStartTime()
+    );
+
+    Schedule saved = scheduleRepository.save(schedule);
+    return new ScheduleSimpleResponse(saved.getId(), saved.getStartTime(),
+        saved.getTicketingStartTime());
+  }
+
+  @Override
+  @Transactional
+  public ScheduleSimpleResponse updateSchedule(Long id, ScheduleUpdateRequest request) {
+    Schedule schedule = scheduleRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException("해당 회차가 존재하지 않습니다."));
+
+    schedule.update(request.startTime(), request.ticketingStartTime());
+
+    return new ScheduleSimpleResponse(schedule.getId(), schedule.getStartTime(),
+        schedule.getTicketingStartTime());
+  }
+
+  @Override
+  @Transactional
+  public void deleteSchedule(Long id) {
+    if (!scheduleRepository.existsById(id)) {
+      throw new EntityNotFoundException("해당 회차가 존재하지 않습니다.");
+    }
+    scheduleRepository.deleteById(id);
+  }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- Schedule 도메인 API 개발
- Concert 연관 회차 등록/수정/삭제 기능 구현

---

## 🛠️ 변경 사항

###  ScheduleController 구현 (`/schedules`)

- `POST /schedules`: 공연 회차 등록
- `PUT /schedules/{id}`: 공연 회차 수정
- `DELETE /schedules/{id}`: 공연 회차 삭제

###  ScheduleService, ScheduleServiceImpl 구현

- `createSchedule(ScheduleCreateRequest)`
- `updateSchedule(Long id, ScheduleUpdateRequest)`
- `deleteSchedule(Long id)`
> 등록 시 concertId를 기반으로 연관 공연 설정

###  DTO 정의

- `ScheduleUpdateRequest`: 회차 수정 요청 DTO(record 기반)

---


## 🧯 해결해야 할 문제

###  공통 응답 포맷 (`ApiResponse<T>`) 미적용

- 현재 `ResponseEntity`로 응답 처리
- 추후 `success`, `message`, `data` 구조의 통일된 공통 응답 포맷 적용 예정

###  예외 처리 보완 필요

- 존재하지 않는 공연 또는 회차 ID 요청 시 `NoSuchElementException` 사용
- 향후 도메인 전용 예외 클래스 도입 및 전역 예외 처리 핸들러 추가 예정

###  인증/권한 처리 미적용

- 현재는 인증 없는 상태에서 회차 생성/수정/삭제 가능
- 이후 JWT 기반 인증 필터 또는 인터셉터 연동 필요
- 권한(예: 공연 등록자만 회차 등록 가능) 검증 로직은 추후 도입

---

## 📌 참고 사항

- QueryDSL, Fetch Join 등을 통한 조회 성능 개선은 추후 적용

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인