### PR TITLE
feat : implement venue-api

### DIFF
--- a/src/main/java/org/example/siljeun/domain/venue/controller/VenueController.java
+++ b/src/main/java/org/example/siljeun/domain/venue/controller/VenueController.java
@@ -1,0 +1,43 @@
+package org.example.siljeun.domain.venue.controller;
+
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.example.siljeun.domain.venue.dto.request.VenueCreateRequest;
+import org.example.siljeun.domain.venue.dto.request.VenueUpdateRequest;
+import org.example.siljeun.domain.venue.service.VenueService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/venues")
+public class VenueController {
+
+  private final VenueService venueService;
+
+  @PostMapping
+  public ResponseEntity<Long> createVenue(@RequestBody @Valid VenueCreateRequest request) {
+    Long venueId = venueService.createVenue(request);
+    return ResponseEntity.created(URI.create("/venues/" + venueId)).body(venueId);
+  }
+
+  @PutMapping("/{venueId}")
+  public ResponseEntity<Void> updateVenue(@PathVariable Long venueId,
+      @RequestBody @Valid VenueUpdateRequest request) {
+    venueService.updateVenue(venueId, request);
+    return ResponseEntity.ok().build();
+  }
+
+  @DeleteMapping("/{venueId}")
+  public ResponseEntity<Void> deleteVenue(@PathVariable Long venueId) {
+    venueService.deleteVenue(venueId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/org/example/siljeun/domain/venue/entity/Venue.java
+++ b/src/main/java/org/example/siljeun/domain/venue/entity/Venue.java
@@ -7,9 +7,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.siljeun.global.entity.BaseEntity;
 
 @Entity
+@NoArgsConstructor
 @Getter
 @Table(name = "venue")
 public class Venue extends BaseEntity {
@@ -27,4 +29,15 @@ public class Venue extends BaseEntity {
   @Column(nullable = false)
   private Integer seatCapacity;
 
+  public Venue(String name, String location, int seatCapacity) {
+    this.name = name;
+    this.location = location;
+    this.seatCapacity = seatCapacity;
+  }
+
+  public void update(String name, String location, int seatCapacity) {
+    this.name = name;
+    this.location = location;
+    this.seatCapacity = seatCapacity;
+  }
 }

--- a/src/main/java/org/example/siljeun/domain/venue/service/VenueService.java
+++ b/src/main/java/org/example/siljeun/domain/venue/service/VenueService.java
@@ -1,0 +1,14 @@
+package org.example.siljeun.domain.venue.service;
+
+import org.example.siljeun.domain.venue.dto.request.VenueCreateRequest;
+import org.example.siljeun.domain.venue.dto.request.VenueUpdateRequest;
+
+public interface VenueService {
+
+  Long createVenue(VenueCreateRequest request);
+
+  void updateVenue(Long venueId, VenueUpdateRequest request);
+
+  void deleteVenue(Long venueId);
+
+}

--- a/src/main/java/org/example/siljeun/domain/venue/service/VenueServiceImpl.java
+++ b/src/main/java/org/example/siljeun/domain/venue/service/VenueServiceImpl.java
@@ -1,0 +1,44 @@
+package org.example.siljeun.domain.venue.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.example.siljeun.domain.venue.dto.request.VenueCreateRequest;
+import org.example.siljeun.domain.venue.dto.request.VenueUpdateRequest;
+import org.example.siljeun.domain.venue.entity.Venue;
+import org.example.siljeun.domain.venue.repository.VenueRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VenueServiceImpl implements VenueService {
+
+  private final VenueRepository venueRepository;
+
+  @Override
+  @Transactional
+  public Long createVenue(VenueCreateRequest request) {
+    Venue venue = new Venue(
+        request.name(),
+        request.location(),
+        request.seatCapacity()
+    );
+    return venueRepository.save(venue).getId();
+  }
+
+  @Override
+  @Transactional
+  public void updateVenue(Long venueId, VenueUpdateRequest request) {
+    Venue venue = venueRepository.findById(venueId)
+        .orElseThrow(() -> new EntityNotFoundException("공연장을 찾을 수 없습니다."));
+
+    venue.update(request.name(), request.location(), request.seatCapacity());
+  }
+
+  @Override
+  public void deleteVenue(Long venueId) {
+    venueRepository.deleteById(venueId);
+  }
+
+}


### PR DESCRIPTION
## 🔎 작업 내용

- Venue 도메인 API 개발

---

## 🛠️ 변경 사항

###  VenueController 구현 (`/venues`)

- `POST /venues`: 공연장  등록
- `PUT /venues/{id}`: 공연장 수정
- `DELETE /venues/{id}`: 공연장 삭제

###  VenueService, VenueServiceImpl 구현

- `createVenues(VenueCreateRequest)`
- `updateVenue(Long id, VenueUpdateRequest)`
- `deleteVenue(Long id)`


---
