### PR TITLE
feat : 좌석 생성, 회차별 좌석 상태정보 생성 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,6 @@ dependencies {
 
 }
 
-tasks.named('test') {
+test {
     useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/siljeun/domain/schedule/controller/SeatScheduleInfoController.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/controller/SeatScheduleInfoController.java
@@ -1,0 +1,13 @@
+package org.example.siljeun.domain.schedule.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/schedules")
+public class SeatScheduleInfoController {
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/repository/SeatScheduleInfoRepository.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/repository/SeatScheduleInfoRepository.java
@@ -1,0 +1,8 @@
+package org.example.siljeun.domain.schedule.repository;
+
+import org.example.siljeun.domain.seat.entity.SeatScheduleInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatScheduleInfoRepository extends JpaRepository<SeatScheduleInfo, Long> {
+
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleServiceImpl.java
@@ -1,7 +1,10 @@
 package org.example.siljeun.domain.schedule.service;
 
 import jakarta.persistence.EntityNotFoundException;
+
+import java.util.List;
 import java.util.NoSuchElementException;
+
 import lombok.RequiredArgsConstructor;
 import org.example.siljeun.domain.concert.entity.Concert;
 import org.example.siljeun.domain.concert.repository.ConcertRepository;
@@ -10,6 +13,11 @@ import org.example.siljeun.domain.schedule.dto.request.ScheduleUpdateRequest;
 import org.example.siljeun.domain.schedule.dto.response.ScheduleSimpleResponse;
 import org.example.siljeun.domain.schedule.entity.Schedule;
 import org.example.siljeun.domain.schedule.repository.ScheduleRepository;
+import org.example.siljeun.domain.schedule.repository.SeatScheduleInfoRepository;
+import org.example.siljeun.domain.seat.entity.Seat;
+import org.example.siljeun.domain.seat.entity.SeatScheduleInfo;
+import org.example.siljeun.domain.seat.enums.SeatStatus;
+import org.example.siljeun.domain.venue.repository.VenueSeatRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,44 +26,61 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ScheduleServiceImpl implements ScheduleService {
 
-  private final ScheduleRepository scheduleRepository;
-  private final ConcertRepository concertRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final ConcertRepository concertRepository;
+    private final VenueSeatRepository venueSeatRepository;
+    private final SeatScheduleInfoRepository seatScheduleInfoRepository;
 
-  @Override
-  @Transactional
-  public ScheduleSimpleResponse createSchedule(ScheduleCreateRequest request) {
-    Concert concert = concertRepository.findById(request.concertId())
-        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 공연입니다."));
+    @Override
+    @Transactional
+    public ScheduleSimpleResponse createSchedule(ScheduleCreateRequest request) {
+        Concert concert = concertRepository.findById(request.concertId())
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 공연입니다."));
 
-    Schedule schedule = new Schedule(
-        concert,
-        request.startTime(),
-        request.ticketingStartTime()
-    );
+        Schedule schedule = new Schedule(
+                concert,
+                request.startTime(),
+                request.ticketingStartTime()
+        );
 
-    Schedule saved = scheduleRepository.save(schedule);
-    return new ScheduleSimpleResponse(saved.getId(), saved.getStartTime(),
-        saved.getTicketingStartTime());
-  }
+        Schedule saved = scheduleRepository.save(schedule);
 
-  @Override
-  @Transactional
-  public ScheduleSimpleResponse updateSchedule(Long id, ScheduleUpdateRequest request) {
-    Schedule schedule = scheduleRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException("해당 회차가 존재하지 않습니다."));
+        //회차 생성 시, 회차별 좌석 정보도 함께 생성
+        List<Seat> seats = venueSeatRepository.findByVenue(concert.getVenue());
 
-    schedule.update(request.startTime(), request.ticketingStartTime());
+        List<SeatScheduleInfo> seatInfos = seats.stream()
+                .map(seat -> SeatScheduleInfo.from(
+                        seat,
+                        schedule,
+                        SeatStatus.AVAILABLE,
+                        seat.getDefaultGrade(),
+                        seat.getDefaultPrice())
+                ).toList();
 
-    return new ScheduleSimpleResponse(schedule.getId(), schedule.getStartTime(),
-        schedule.getTicketingStartTime());
-  }
+        seatScheduleInfoRepository.saveAll(seatInfos);
 
-  @Override
-  @Transactional
-  public void deleteSchedule(Long id) {
-    if (!scheduleRepository.existsById(id)) {
-      throw new EntityNotFoundException("해당 회차가 존재하지 않습니다.");
+        return new ScheduleSimpleResponse(saved.getId(), saved.getStartTime(),
+                saved.getTicketingStartTime());
     }
-    scheduleRepository.deleteById(id);
-  }
+
+    @Override
+    @Transactional
+    public ScheduleSimpleResponse updateSchedule(Long id, ScheduleUpdateRequest request) {
+        Schedule schedule = scheduleRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("해당 회차가 존재하지 않습니다."));
+
+        schedule.update(request.startTime(), request.ticketingStartTime());
+
+        return new ScheduleSimpleResponse(schedule.getId(), schedule.getStartTime(),
+                schedule.getTicketingStartTime());
+    }
+
+    @Override
+    @Transactional
+    public void deleteSchedule(Long id) {
+        if (!scheduleRepository.existsById(id)) {
+            throw new EntityNotFoundException("해당 회차가 존재하지 않습니다.");
+        }
+        scheduleRepository.deleteById(id);
+    }
 }

--- a/src/main/java/org/example/siljeun/domain/schedule/service/SeatScheduleInfoService.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/service/SeatScheduleInfoService.java
@@ -1,0 +1,9 @@
+package org.example.siljeun.domain.schedule.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SeatScheduleInfoService {
+}

--- a/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatCreateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatCreateRequest.java
@@ -10,5 +10,4 @@ public record SeatCreateRequest(
         @NotBlank String defaultGrade,
         @Min(0) int defaultPrice
 ) {
-
 }

--- a/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatCreateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatCreateRequest.java
@@ -1,0 +1,14 @@
+package org.example.siljeun.domain.seat.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record SeatCreateRequest(
+        @NotBlank String section,
+        @NotBlank String row,
+        @NotBlank String column,
+        @NotBlank String defaultGrade,
+        @Min(0) int defaultPrice
+) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatScheduleInfoCreateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatScheduleInfoCreateRequest.java
@@ -1,0 +1,14 @@
+package org.example.siljeun.domain.seat.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.siljeun.domain.seat.enums.SeatStatus;
+
+public record SeatScheduleInfoCreateRequest(
+        @NotBlank Long seatId,
+        @NotNull SeatStatus status,
+        @Nullable String grade,
+        @Nullable Integer price
+) {
+}

--- a/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatScheduleUpdateInfoRequest.java
+++ b/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatScheduleUpdateInfoRequest.java
@@ -1,0 +1,15 @@
+package org.example.siljeun.domain.seat.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.siljeun.domain.seat.enums.SeatStatus;
+
+//for PUT API
+public record SeatScheduleUpdateInfoRequest(
+        @NotNull Long seatScheduleInfoId,
+        @NotNull SeatStatus status,
+        @NotBlank String grade,
+        @Min(0) int price
+) {
+}

--- a/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatScheduleUpdateStatusRequest.java
+++ b/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatScheduleUpdateStatusRequest.java
@@ -1,0 +1,12 @@
+package org.example.siljeun.domain.seat.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.example.siljeun.domain.seat.enums.SeatStatus;
+
+//for PATCH API
+public record SeatScheduleUpdateStatusRequest(
+        @NotNull Long seatScheduleInfoId,
+        @NotNull SeatStatus status
+) {
+
+}

--- a/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatScheduleUpdateStatusRequest.java
+++ b/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatScheduleUpdateStatusRequest.java
@@ -8,5 +8,4 @@ public record SeatScheduleUpdateStatusRequest(
         @NotNull Long seatScheduleInfoId,
         @NotNull SeatStatus status
 ) {
-
 }

--- a/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatUpdateRequest.java
+++ b/src/main/java/org/example/siljeun/domain/seat/dto/request/SeatUpdateRequest.java
@@ -1,0 +1,16 @@
+package org.example.siljeun.domain.seat.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+//for PUT API
+public record SeatUpdateRequest(
+        @NotNull Long seatId,
+        @NotBlank String section,
+        @NotBlank String row,
+        @NotBlank String column,
+        @NotBlank String defaultGrade,
+        @Min(0) int defaultPrice
+) {
+}

--- a/src/main/java/org/example/siljeun/domain/seat/dto/response/SeatResponse.java
+++ b/src/main/java/org/example/siljeun/domain/seat/dto/response/SeatResponse.java
@@ -1,0 +1,12 @@
+package org.example.siljeun.domain.seat.dto.response;
+
+public record SeatResponse(
+        Long seatId,
+        String section,
+        String row,
+        String column,
+        String seatNumber,
+        String defaultGrade,
+        int defaultPrice
+) {
+}

--- a/src/main/java/org/example/siljeun/domain/seat/dto/response/SeatScheduleInfoResponse.java
+++ b/src/main/java/org/example/siljeun/domain/seat/dto/response/SeatScheduleInfoResponse.java
@@ -1,0 +1,10 @@
+package org.example.siljeun.domain.seat.dto.response;
+
+public record SeatScheduleInfoResponse(
+        Long seatScheduleInfoId,
+        String seatNumber,
+        String status,
+        String grade,
+        int price
+) {
+}

--- a/src/main/java/org/example/siljeun/domain/seat/entity/Seat.java
+++ b/src/main/java/org/example/siljeun/domain/seat/entity/Seat.java
@@ -30,6 +30,8 @@ public class Seat {
 
   private String section;
   private String row;
+  private String column;
   private String number;
-
+  private String defaultGrade;
+  private int defaultPrice;
 }

--- a/src/main/java/org/example/siljeun/domain/seat/entity/Seat.java
+++ b/src/main/java/org/example/siljeun/domain/seat/entity/Seat.java
@@ -1,37 +1,49 @@
 package org.example.siljeun.domain.seat.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.siljeun.domain.seat.dto.request.SeatCreateRequest;
 import org.example.siljeun.domain.venue.entity.Venue;
 
 @Entity
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "seat")
+@Table(
+    name = "seat",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"venue_id", "section", "row", "column"}) //O공연장의 O구역 O열 O좌석은 고유하다
+    }
+)
 public class Seat {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  //공연장 FK
-  @ManyToOne
-  @JoinColumn(name = "venue_id")
-  private Venue venue;
+    //공연장 FK
+    @ManyToOne
+    @JoinColumn(name = "venue_id")
+    private Venue venue;
 
-  private String section;
-  private String row;
-  private String column;
-  private String number;
-  private String defaultGrade;
-  private int defaultPrice;
+    private String section;
+    private String row;
+    private String column;
+    private String defaultGrade;
+    private int defaultPrice;
+
+    private Seat(Venue venue, String section, String row, String column, String defaultGrade, int defaultPrice) {
+        this.venue = venue;
+        this.section = section;
+        this.row = row;
+        this.column = column;
+        this.defaultGrade = defaultGrade;
+        this.defaultPrice = defaultPrice;
+    }
+
+    public static Seat from(Venue venue, SeatCreateRequest request) {
+        return new Seat(venue, request.section(), request.row(), request.column(), request.defaultGrade(), request.defaultPrice());
+    }
 }

--- a/src/main/java/org/example/siljeun/domain/seat/entity/Seat.java
+++ b/src/main/java/org/example/siljeun/domain/seat/entity/Seat.java
@@ -14,7 +14,7 @@ import org.example.siljeun.domain.venue.entity.Venue;
 @Table(
     name = "seat",
     uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"venue_id", "section", "row", "column"}) //O공연장의 O구역 O열 O좌석은 고유하다
+        @UniqueConstraint(columnNames = {"venue_id", "section", "seat_row", "seat_column"}) //O공연장의 O구역 O열 O좌석은 고유하다
     }
 )
 public class Seat {
@@ -29,7 +29,9 @@ public class Seat {
     private Venue venue;
 
     private String section;
+    @Column(name = "seat_row")
     private String row;
+    @Column(name = "seat_column")
     private String column;
     private String defaultGrade;
     private int defaultPrice;

--- a/src/main/java/org/example/siljeun/domain/seat/entity/SeatScheduleInfo.java
+++ b/src/main/java/org/example/siljeun/domain/seat/entity/SeatScheduleInfo.java
@@ -35,12 +35,7 @@ public class SeatScheduleInfo extends BaseEntity {
   @JoinColumn(name = "schedule_id", nullable = false)
   private Schedule schedule;
 
-  //상태 (확장성을 위해 우선 enum으로 설정해놓음)
   private SeatStatus status;
-
-  //임시로 String으로 설정
   private String grade;
-
   private int price;
-
 }

--- a/src/main/java/org/example/siljeun/domain/seat/entity/SeatScheduleInfo.java
+++ b/src/main/java/org/example/siljeun/domain/seat/entity/SeatScheduleInfo.java
@@ -22,20 +22,32 @@ import org.example.siljeun.global.entity.BaseEntity;
 @Table(name = "seat_schedule_info")
 public class SeatScheduleInfo extends BaseEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "seat_id", nullable = false)
-  private Seat seat;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id", nullable = false)
+    private Seat seat;
 
-  //회차 정보
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "schedule_id", nullable = false)
-  private Schedule schedule;
+    //회차 정보
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private Schedule schedule;
 
-  private SeatStatus status;
-  private String grade;
-  private int price;
+    private SeatStatus status;
+    private String grade;
+    private int price;
+
+    private SeatScheduleInfo(Seat seat, Schedule schedule, SeatStatus status, String grade, int price) {
+        this.seat = seat;
+        this.schedule = schedule;
+        this.status = status;
+        this.grade = grade;
+        this.price = price;
+    }
+
+    public static SeatScheduleInfo from(Seat seat, Schedule schedule, SeatStatus status, String grade, int price) {
+        return new SeatScheduleInfo(seat, schedule, status, grade, price);
+    }
 }

--- a/src/main/java/org/example/siljeun/domain/seat/enums/SeatStatus.java
+++ b/src/main/java/org/example/siljeun/domain/seat/enums/SeatStatus.java
@@ -1,6 +1,10 @@
 package org.example.siljeun.domain.seat.enums;
 
 public enum SeatStatus {
-  AVALIABLE,
-  UNAVALIABLE
+    BLOCKED,    //미판매
+    CANCELLED,  //취소
+    RESERVED,   //예매됨
+    HOLD,       //결제 진행 중
+    SELECTED,   //선택됨
+    AVAILABLE   //빈 좌석
 }

--- a/src/main/java/org/example/siljeun/domain/venue/controller/VenueSeatController.java
+++ b/src/main/java/org/example/siljeun/domain/venue/controller/VenueSeatController.java
@@ -1,0 +1,32 @@
+package org.example.siljeun.domain.venue.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.siljeun.domain.seat.dto.request.SeatCreateRequest;
+import org.example.siljeun.domain.venue.service.VenueSeatService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/venues")
+public class VenueSeatController {
+
+    private final VenueSeatService venueSeatService;
+
+    //좌석 정보를 CSV 파일 또는 GUI로 다수의 정보를 한번에 등록한다.
+    @PostMapping("/{venueId}/seats")
+    public ResponseEntity<Void> createVenueSeats(
+            @PathVariable Long venueId,
+            @RequestBody @Valid List<SeatCreateRequest> seatCreateRequests
+    ){
+        venueSeatService.createSeats(venueId, seatCreateRequests);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/example/siljeun/domain/venue/repository/VenueSeatRepository.java
+++ b/src/main/java/org/example/siljeun/domain/venue/repository/VenueSeatRepository.java
@@ -1,0 +1,8 @@
+package org.example.siljeun.domain.venue.repository;
+
+import org.example.siljeun.domain.seat.entity.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VenueSeatRepository extends JpaRepository<Seat, Long> {
+
+}

--- a/src/main/java/org/example/siljeun/domain/venue/repository/VenueSeatRepository.java
+++ b/src/main/java/org/example/siljeun/domain/venue/repository/VenueSeatRepository.java
@@ -1,8 +1,12 @@
 package org.example.siljeun.domain.venue.repository;
 
 import org.example.siljeun.domain.seat.entity.Seat;
+import org.example.siljeun.domain.venue.entity.Venue;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface VenueSeatRepository extends JpaRepository<Seat, Long> {
 
+    List<Seat> findByVenue(Venue venue);
 }

--- a/src/main/java/org/example/siljeun/domain/venue/service/VenueSeatService.java
+++ b/src/main/java/org/example/siljeun/domain/venue/service/VenueSeatService.java
@@ -1,0 +1,37 @@
+package org.example.siljeun.domain.venue.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.siljeun.domain.seat.dto.request.SeatCreateRequest;
+import org.example.siljeun.domain.seat.entity.Seat;
+import org.example.siljeun.domain.venue.entity.Venue;
+import org.example.siljeun.domain.venue.repository.VenueRepository;
+import org.example.siljeun.domain.venue.repository.VenueSeatRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class VenueSeatService {
+
+    private final VenueRepository venueRepository;
+    private final VenueSeatRepository venueSeatRepository;
+
+    @Transactional
+    public void createSeats(Long venueId, List<SeatCreateRequest> seatCreateRequests){
+        Venue venue = venueRepository.findById(venueId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 공연장을 찾을 수 없습니다."));         //Throw 예외 설정 필요
+
+        //공연장 ID, 구역, 열, 번호를 바탕으로 고유하도록 설정하였으나
+        //좌석 정보가 중복되는 경우를 다루지 않아 추후 리팩토링이 필요함
+        List<Seat> seats = seatCreateRequests.stream()
+                .map(request -> Seat.from(venue, request))
+                .toList();
+
+        venueSeatRepository.saveAll(seats);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,1 @@
 spring.application.name=siljeun
-
-jwt.secret.key = ${JWT_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,17 +1,1 @@
 spring.application.name=siljeun
-
-spring.datasource.url=jdbc:mysql://localhost:3306/ticketing
-spring.datasource.username=${DB_USERNAME}
-spring.datasource.password=${DB_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
-spring.jpa.hibernate.ddl-auto=update
-
-spring.jpa.properties.hibernate.show_sql=true
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.properties.hibernate.use_sql_comments=true
-
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-
-jwt.secret.key=${JWT_SECRET_KEY}
-

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=siljeun
+
+jwt.secret.key = ${JWT_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=siljeun
+
+jwt.secret.key=${JWT_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,17 @@
 spring.application.name=siljeun
 
+spring.datasource.url=jdbc:mysql://localhost:3306/ticketing
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.use_sql_comments=true
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
 jwt.secret.key=${JWT_SECRET_KEY}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}


### PR DESCRIPTION

## 🔎 작업 내용

- Seat, SeatScheduleInfo 관련 DTO와 3-Layer 계층 추가
- Seat, SeatScheduleInfo 생성 기능 추가 (시간 관계 상 우선 Create만 구현)

---

## 🛠️ 변경 사항

- `seat` 패키지
   - `dto` 패키지 내에 Request, Response Dto 추가
   - `entity` 패키지 내에 생성자 및 정적 메서드 추가
- `venue` 패키지
  - `VenueSeat` 3-Layer 계층 추가
- `schedule`패키지
  - `SeatScheduleInfo` 3-Layer 계층 추가
  - `ScheduleServiceImpl` 클래스의 `createSchedule` 메서드 내 `SeatScheduleInfo` 초기 생성 로직 추가     
---

## 🧩 트러블 슈팅

---

## 🧯 해결해야 할 문제

- `VenueSeat` 생성 시, CSV 파일이나 GUI를 기반으로 전체 좌석 정보를 배열로 받는다는 가정 하에 구현하였는데, `등록하려는 데이터 내의 중복된 좌석 데이터 존재` 또는 `DB에 이미 동일한 좌석이 존재` 하는 경우에서의 예외처리를 구현하지 않아 추후 리팩토링의 필요성이 있음

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인