### PR TITLE
reafactor : schedule-api apply querydsl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,13 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/siljeun/domain/concert/controller/ConcertController.java
+++ b/src/main/java/org/example/siljeun/domain/concert/controller/ConcertController.java
@@ -9,13 +9,14 @@ import org.example.siljeun.domain.concert.dto.request.ConcertUpdateRequest;
 import org.example.siljeun.domain.concert.dto.response.ConcertDetailResponse;
 import org.example.siljeun.domain.concert.dto.response.ConcertSimpleResponse;
 import org.example.siljeun.domain.concert.service.ConcertService;
+import org.example.siljeun.global.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,9 +31,9 @@ public class ConcertController {
   @PostMapping
   public ResponseEntity<Long> createConcert(
       @RequestBody @Valid ConcertCreateRequest request,
-      @RequestAttribute("userId") Long userId
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    Long concertId = concertService.createConcert(request, userId);
+    Long concertId = concertService.createConcert(request, userDetails.getUserId());
     return ResponseEntity.created(URI.create("/concerts" + concertId)).body(concertId);
   }
 

--- a/src/main/java/org/example/siljeun/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/controller/ScheduleController.java
@@ -1,5 +1,6 @@
 package org.example.siljeun.domain.schedule.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.siljeun.domain.schedule.dto.request.ScheduleCreateRequest;
 import org.example.siljeun.domain.schedule.dto.request.ScheduleUpdateRequest;
@@ -7,11 +8,13 @@ import org.example.siljeun.domain.schedule.dto.response.ScheduleSimpleResponse;
 import org.example.siljeun.domain.schedule.service.ScheduleService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,6 +44,14 @@ public class ScheduleController {
   public ResponseEntity<Void> deleteSchedule(@PathVariable Long id) {
     scheduleService.deleteSchedule(id);
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping
+  public ResponseEntity<List<ScheduleSimpleResponse>> getSchedulesByConcertId(
+      @RequestParam Long concertId
+  ) {
+    List<ScheduleSimpleResponse> response = scheduleService.getSchedulesByConcertId(concertId);
+    return ResponseEntity.ok(response);
   }
 
 }

--- a/src/main/java/org/example/siljeun/domain/schedule/repository/ScheduleQueryRepository.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/repository/ScheduleQueryRepository.java
@@ -1,0 +1,10 @@
+package org.example.siljeun.domain.schedule.repository;
+
+import java.util.List;
+import org.example.siljeun.domain.schedule.entity.Schedule;
+
+public interface ScheduleQueryRepository {
+  
+  List<Schedule> findByConcertIdWithConcert(Long concertId);
+
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/repository/ScheduleQueryRepositoryImpl.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/repository/ScheduleQueryRepositoryImpl.java
@@ -1,0 +1,27 @@
+package org.example.siljeun.domain.schedule.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.example.siljeun.domain.concert.entity.QConcert;
+import org.example.siljeun.domain.schedule.entity.QSchedule;
+import org.example.siljeun.domain.schedule.entity.Schedule;
+
+
+@RequiredArgsConstructor
+public class ScheduleQueryRepositoryImpl implements ScheduleQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+  private final QSchedule schedule = QSchedule.schedule;
+  private final QConcert concert = QConcert.concert;
+
+  @Override
+  public List<Schedule> findByConcertIdWithConcert(Long concertId) {
+    return queryFactory
+        .selectFrom(schedule)
+        .join(schedule.concert, concert).fetchJoin()
+        .where(schedule.concert.id.eq(concertId))
+        .fetch();
+  }
+
+}

--- a/src/main/java/org/example/siljeun/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/repository/ScheduleRepository.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.example.siljeun.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+public interface ScheduleRepository extends JpaRepository<Schedule, Long>, ScheduleQueryRepository {
 
   List<Schedule> findByConcertId(Long concertId);
 }

--- a/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleService.java
@@ -1,5 +1,6 @@
 package org.example.siljeun.domain.schedule.service;
 
+import java.util.List;
 import org.example.siljeun.domain.schedule.dto.request.ScheduleCreateRequest;
 import org.example.siljeun.domain.schedule.dto.request.ScheduleUpdateRequest;
 import org.example.siljeun.domain.schedule.dto.response.ScheduleSimpleResponse;
@@ -11,5 +12,7 @@ public interface ScheduleService {
   ScheduleSimpleResponse updateSchedule(Long id, ScheduleUpdateRequest request);
 
   void deleteSchedule(Long id);
+
+  List<ScheduleSimpleResponse> getSchedulesByConcertId(Long concertId);
 
 }

--- a/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/example/siljeun/domain/schedule/service/ScheduleServiceImpl.java
@@ -1,6 +1,7 @@
 package org.example.siljeun.domain.schedule.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.example.siljeun.domain.concert.entity.Concert;
@@ -57,5 +58,15 @@ public class ScheduleServiceImpl implements ScheduleService {
       throw new EntityNotFoundException("해당 회차가 존재하지 않습니다.");
     }
     scheduleRepository.deleteById(id);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<ScheduleSimpleResponse> getSchedulesByConcertId(Long concertId) {
+    List<Schedule> schedules = scheduleRepository.findByConcertIdWithConcert(concertId);
+    return schedules.stream()
+        .map(
+            s -> new ScheduleSimpleResponse(s.getId(), s.getStartTime(), s.getTicketingStartTime()))
+        .toList();
   }
 }

--- a/src/main/java/org/example/siljeun/global/config/QuerydslConfig.java
+++ b/src/main/java/org/example/siljeun/global/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package org.example.siljeun.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+    return new JPAQueryFactory(em);
+  }
+}

--- a/src/main/java/org/example/siljeun/global/dto/ResponseDto.java
+++ b/src/main/java/org/example/siljeun/global/dto/ResponseDto.java
@@ -1,7 +1,11 @@
 package org.example.siljeun.global.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @AllArgsConstructor
 public class ResponseDto<T> {
 


### PR DESCRIPTION
## 🔎 작업 내용

- Schedule API에 QueryDSL을 적용하여 N+1 문제를 해결
- 컨트롤러에서 사용자 인증 정보를 @AuthenticationPrincipal 기반으로 처리하도록 수정
- ResponseDto에 직렬화를 위한 @Getter 및 @JsonInclude 설정 추가

---

## 🛠️ 변경 사항

- `ScheduleQueryRepository` / `ScheduleQueryRepositoryImpl` 생성 및 `fetchJoin` 쿼리 적용
- `ScheduleServiceImpl.getSchedulesByConcertId()`에서 QueryDSL 기반 조회 적용
- `@RequestAttribute("userId")` 제거 → `@AuthenticationPrincipal CustomUserDetails`로 대체
- `ResponseDto`에 `@Getter` 추가 및 `@JsonInclude(JsonInclude.Include.NON_NULL)` 적용

---


## 🧯 해결해야 할 문제

- 공연 상세 조회 시 schedule이 함께 조회되는 구조라면 schedule 단독 조회 API가 정말 필요한지 검토
- 
---

## 📌 참고 사항

- QueryDSL 공식 문서: https://querydsl.com/static/querydsl/5.0.0/reference/html_single/
- `@AuthenticationPrincipal` 공식 가이드: https://docs.spring.io/spring-security/reference/servlet/authentication/principal.html

---
