### PR TITLE
feat: 인기공연 조회 캐싱 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.27.1'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.data:spring-data-redis'
+    implementation 'org.apache.commons:commons-pool2'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
@@ -57,6 +61,7 @@ dependencies {
 
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/siljeun/domain/concert/controller/ConcertController.java
+++ b/src/main/java/org/example/siljeun/domain/concert/controller/ConcertController.java
@@ -63,4 +63,9 @@ public class ConcertController {
     ConcertDetailResponse response = concertService.getConcertDetail(concertId);
     return ResponseEntity.ok(response);
   }
+
+  @GetMapping("/popular")
+  public ResponseEntity<List<ConcertSimpleResponse>> getPopularConcerts() {
+    return ResponseEntity.ok(concertService.getPopularConcerts());
+  }
 }

--- a/src/main/java/org/example/siljeun/domain/concert/repository/ConcertRepository.java
+++ b/src/main/java/org/example/siljeun/domain/concert/repository/ConcertRepository.java
@@ -1,8 +1,11 @@
 package org.example.siljeun.domain.concert.repository;
 
+import java.util.List;
 import org.example.siljeun.domain.concert.entity.Concert;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ConcertRepository extends JpaRepository<Concert, Long> {
+
+  List<Concert> findByIdIn(List<Long> ids);
 
 }

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertCacheService.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertCacheService.java
@@ -1,0 +1,32 @@
+package org.example.siljeun.domain.concert.service;
+
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ConcertCacheService {
+
+  @Qualifier("redisJsonTemplate")
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  private static final String RANK_KEY = "concert:ranking";
+
+  public void increaseViewCount(Long concertId) {
+    redisTemplate.opsForZSet().incrementScore(RANK_KEY, concertId, 1);
+  }
+
+  public List<Long> getTopConcertIds(int limit) {
+    Set<Object> ids = redisTemplate.opsForZSet()
+        .reverseRange(RANK_KEY, 0, limit - 1);
+
+    return ids.stream()
+        .map(id -> Long.valueOf(id.toString()))
+        .toList();
+  }
+
+}

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertService.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertService.java
@@ -18,4 +18,5 @@ public interface ConcertService {
 
   ConcertDetailResponse getConcertDetail(Long concertId);
 
+  List<ConcertSimpleResponse> getPopularConcerts();
 }

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertServiceImpl.java
@@ -2,6 +2,9 @@ package org.example.siljeun.domain.concert.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.example.siljeun.domain.concert.dto.request.ConcertCreateRequest;
 import org.example.siljeun.domain.concert.dto.request.ConcertUpdateRequest;
@@ -27,6 +30,7 @@ public class ConcertServiceImpl implements ConcertService {
   private final VenueRepository venueRepository;
   private final UserRepository userRepository;
   private final ScheduleRepository scheduleRepository;
+  private final ConcertCacheService concertCacheService;
 
 
   @Override
@@ -84,6 +88,9 @@ public class ConcertServiceImpl implements ConcertService {
 
   @Override
   public ConcertDetailResponse getConcertDetail(Long concertId) {
+
+    concertCacheService.increaseViewCount(concertId);
+
     Concert concert = concertRepository.findById(concertId)
         .orElseThrow(() -> new EntityNotFoundException("해당 공연이 존재하지 않습니다."));
 
@@ -110,5 +117,25 @@ public class ConcertServiceImpl implements ConcertService {
         venueResponse,
         schedules
     );
+  }
+
+  @Override
+  public List<ConcertSimpleResponse> getPopularConcerts() {
+    List<Long> topIds = concertCacheService.getTopConcertIds(7);
+    List<Concert> concerts = concertRepository.findByIdIn(topIds);
+
+    Map<Long, Concert> concertMap = concerts.stream()
+        .collect(Collectors.toMap(Concert::getId, c -> c));
+
+    return topIds.stream()
+        .map(concertMap::get)
+        .filter(Objects::nonNull)
+        .map(c -> new ConcertSimpleResponse(
+            c.getId(),
+            c.getTitle(),
+            c.getVenue().getName(),
+            c.getCategory().name()
+        ))
+        .toList();
   }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- Redis를 이용해 공연 조회수 기반 인기 공연 캐싱 기능 구현
- `ConcertService.getConcertDetail()` 시 조회수 증가 처리
- `/api/concerts/popular` API 추가: Redis의 Sorted Set 기반 상위 공연 조회
- Redis 설정 개선 (`RedisTemplate` 분리: 숫자용 / JSON용)
- QueryDSL 성능 개선 작업을 위한 Redis 기반 캐시 도입 구조 완성

---

## 🛠️ 변경 사항

###  ConcertController

- `GET /api/concerts/popular`: 인기 공연 목록 조회 API 추가

###  ConcertService / ConcertServiceImpl

- `increaseViewCount(concertId)`: 공연 상세 조회 시 Redis Sorted Set으로 조회수 증가
- `getPopularConcerts()`: 조회수 기준 상위 7개 공연 조회 (ZSet 기준)
- DB에서 top ID 목록을 조회 후 `findByIdIn()`으로 fetch

###  ConcertCacheService

- RedisTemplate 기반 Sorted Set(ZSet) 캐시 처리 전담 서비스
- `increaseViewCount(Long concertId)` → 조회수 +1
- `getTopConcertIds(int limit)` → ZREVRANGE로 상위 N개 ID 추출

###  ConcertRepository

- `List<Concert> findByIdIn(List<Long> ids)` 메서드 추가

###  RedisConfig

- 기존 `redisTemplate()` 메서드를 다음과 같이 분리:
  - `redisLongTemplate`: Long 기반 캐시용
  - `redisJsonTemplate`: 객체 JSON 직렬화용 (ex: DTO 캐싱 시)
- Redisson 설정 포함 (`RedissonClient` 빈 등록)

---

## 🧯 해결해야 할 문제

###  캐시 초기화 전략 미정

- Redis 서버 재시작 시 조회수 초기화됨
- 향후 배치 작업 또는 DB와의 동기화 전략 필요

###  Redis 성능 튜닝 미적용

- 현재 모든 캐시는 기본 ZSet 기반으로만 구성
- TTL 설정 및 eviction 정책 검토 필요

---

## 📌 참고

- 인기 공연 캐시는 정렬 가능한 ZSet(`concert:ranking`)을 사용
- QueryDSL 성능 개선 브랜치에서 실제 캐시 기반으로 데이터 활용 가능
- RedisTemplate 분리 구조는 추후 JSON 캐싱 또는 사용자 기반 캐시 구조에 재활용 가능
