### PR TITLE
Feat: ttl 적용하여 캐싱 기능 개선

### DIFF
--- a/src/main/java/org/example/siljeun/domain/concert/controller/ConcertController.java
+++ b/src/main/java/org/example/siljeun/domain/concert/controller/ConcertController.java
@@ -64,8 +64,13 @@ public class ConcertController {
     return ResponseEntity.ok(response);
   }
 
-  @GetMapping("/popular")
-  public ResponseEntity<List<ConcertSimpleResponse>> getPopularConcerts() {
-    return ResponseEntity.ok(concertService.getPopularConcerts());
+  @GetMapping("/popular/daily")
+  public ResponseEntity<List<ConcertSimpleResponse>> getDailyPopularConcerts() {
+    return ResponseEntity.ok(concertService.getDailyPopularConcerts());
+  }
+
+  @GetMapping("/popular/weekly")
+  public ResponseEntity<List<ConcertSimpleResponse>> getWeeklyPopularConcerts() {
+    return ResponseEntity.ok(concertService.getWeeklyPopularConcerts());
   }
 }

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertCacheService.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertCacheService.java
@@ -38,4 +38,10 @@ public class ConcertCacheService {
         .toList();
   }
 
+  public List<Long> getTopConcertIds(String key, int limit) {
+    Set<Object> ids = redisTemplate.opsForZSet()
+        .reverseRange(key, 0, limit - 1);
+    return ids.stream().map(id -> Long.valueOf(id.toString())).toList();
+  }
+
 }

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertCacheService.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertCacheService.java
@@ -1,6 +1,5 @@
 package org.example.siljeun.domain.concert.service;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -17,16 +16,8 @@ public class ConcertCacheService {
 
   private static final String RANK_KEY = "concert:ranking";
 
-  public void increaseDailyViewCount(Long concertId) {
-    String key = "ranking:daily";
-    redisTemplate.opsForZSet().incrementScore(key, concertId, 1);
-    redisTemplate.expire(key, Duration.ofDays(1));
-  }
-
-  public void increaseWeeklyViewCount(Long concertId) {
-    String key = "ranking:weekly";
-    redisTemplate.opsForZSet().incrementScore(key, concertId, 1);
-    redisTemplate.expire(key, Duration.ofDays(7));
+  public void increaseViewCount(Long concertId) {
+    redisTemplate.opsForZSet().incrementScore(RANK_KEY, concertId, 1);
   }
 
   public List<Long> getTopConcertIds(int limit) {

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertCacheService.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertCacheService.java
@@ -1,5 +1,6 @@
 package org.example.siljeun.domain.concert.service;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +17,16 @@ public class ConcertCacheService {
 
   private static final String RANK_KEY = "concert:ranking";
 
-  public void increaseViewCount(Long concertId) {
-    redisTemplate.opsForZSet().incrementScore(RANK_KEY, concertId, 1);
+  public void increaseDailyViewCount(Long concertId) {
+    String key = "ranking:daily";
+    redisTemplate.opsForZSet().incrementScore(key, concertId, 1);
+    redisTemplate.expire(key, Duration.ofDays(1));
+  }
+
+  public void increaseWeeklyViewCount(Long concertId) {
+    String key = "ranking:weekly";
+    redisTemplate.opsForZSet().incrementScore(key, concertId, 1);
+    redisTemplate.expire(key, Duration.ofDays(7));
   }
 
   public List<Long> getTopConcertIds(int limit) {

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertService.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertService.java
@@ -18,5 +18,7 @@ public interface ConcertService {
 
   ConcertDetailResponse getConcertDetail(Long concertId);
 
-  List<ConcertSimpleResponse> getPopularConcerts();
+  List<ConcertSimpleResponse> getDailyPopularConcerts();
+
+  List<ConcertSimpleResponse> getWeeklyPopularConcerts();
 }

--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertServiceImpl.java
@@ -120,21 +120,26 @@ public class ConcertServiceImpl implements ConcertService {
   }
 
   @Override
-  public List<ConcertSimpleResponse> getPopularConcerts() {
-    List<Long> topIds = concertCacheService.getTopConcertIds(7);
-    List<Concert> concerts = concertRepository.findByIdIn(topIds);
+  public List<ConcertSimpleResponse> getDailyPopularConcerts() {
+    List<Long> ids = concertCacheService.getTopConcertIds("ranking:daily", 7);
+    return mapConcertsByIdOrder(ids);
+  }
 
+  @Override
+  public List<ConcertSimpleResponse> getWeeklyPopularConcerts() {
+    List<Long> ids = concertCacheService.getTopConcertIds("ranking:weekly", 7);
+    return mapConcertsByIdOrder(ids);
+  }
+
+  private List<ConcertSimpleResponse> mapConcertsByIdOrder(List<Long> ids) {
+    List<Concert> concerts = concertRepository.findByIdIn(ids);
     Map<Long, Concert> concertMap = concerts.stream()
         .collect(Collectors.toMap(Concert::getId, c -> c));
-
-    return topIds.stream()
+    return ids.stream()
         .map(concertMap::get)
         .filter(Objects::nonNull)
         .map(c -> new ConcertSimpleResponse(
-            c.getId(),
-            c.getTitle(),
-            c.getVenue().getName(),
-            c.getCategory().name()
+            c.getId(), c.getTitle(), c.getVenue().getName(), c.getCategory().name()
         ))
         .toList();
   }


### PR DESCRIPTION
## 🔎 작업 내용

- Redis Sorted Set(ZSet)을 활용해 **일간 인기 공연**, **주간 인기 공연** 캐싱 및 조회 기능 구현
- `/api/concerts/popular/daily`, `/api/concerts/popular/weekly` API 추가
- 기존 인기 공연 조회 캐시 로직을 공통화하여 재사용 가능하도록 리팩토링

---

## 🛠️ 변경 사항

###  ConcertController

- `GET /api/concerts/popular/daily`: 일간 인기 공연 조회
- `GET /api/concerts/popular/weekly`: 주간 인기 공연 조회

###  ConcertService / ConcertServiceImpl

- `getDailyPopularConcerts()` 구현
- `getWeeklyPopularConcerts()` 구현
- Redis Sorted Set 키를 기반으로 인기 공연 ID 조회 후 DB에서 fetch
- `mapConcertsByIdOrder(List<Long>)` 메서드 추가: ID 순서 보장하며 DTO 변환

###  ConcertCacheService

- `getTopConcertIds(String key, int limit)` 메서드 추가
  - 키 값을 파라미터로 받아 재사용 가능 (e.g., `ranking:daily`, `ranking:weekly`)
- 기존 `getTopConcertIds(limit)`은 기본 캐싱 키(`concert:ranking`)로 조회

---


