### PR TITLE
Refactor: 공연장 삭제 softdelete적용 및 레디스 캐싱 개선

### DIFF
--- a/src/main/java/org/example/siljeun/domain/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/org/example/siljeun/domain/concert/service/ConcertServiceImpl.java
@@ -36,8 +36,8 @@ public class ConcertServiceImpl implements ConcertService {
   @Override
   @Transactional
   public Long createConcert(ConcertCreateRequest request, Long userId) {
-    Venue venue = venueRepository.findById(request.venuId())
-        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 공연장입니다."));
+    Venue venue = venueRepository.findByIdAndDeletedAtIsNull(request.venuId())
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않거나 삭제된 공연장입니다."));
 
     Concert concert = Concert.builder()
         .title(request.title())
@@ -56,8 +56,8 @@ public class ConcertServiceImpl implements ConcertService {
     Concert concert = concertRepository.findById(concertId)
         .orElseThrow(() -> new EntityNotFoundException("해당 공연이 존재하지 않습니다."));
 
-    Venue venue = venueRepository.findById(request.venueId())
-        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 공연장입니다."));
+    Venue venue = venueRepository.findByIdAndDeletedAtIsNull(request.venueId())
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않거나 삭제된 공연장입니다."));
 
     concert.update(
         request.title(),
@@ -93,6 +93,11 @@ public class ConcertServiceImpl implements ConcertService {
 
     Concert concert = concertRepository.findById(concertId)
         .orElseThrow(() -> new EntityNotFoundException("해당 공연이 존재하지 않습니다."));
+
+    Venue venue = concert.getVenue();
+    if (venue.isDeleted()) {
+      throw new IllegalStateException("해당 공연장은 삭제되어 공연 상세 정보를 조회할 수 없습니다.");
+    }
 
     VenueSimpleResponse venueResponse = new VenueSimpleResponse(
         concert.getVenue().getId(),

--- a/src/main/java/org/example/siljeun/domain/venue/entity/Venue.java
+++ b/src/main/java/org/example/siljeun/domain/venue/entity/Venue.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.siljeun.global.entity.BaseEntity;
@@ -29,6 +30,8 @@ public class Venue extends BaseEntity {
   @Column(nullable = false)
   private Integer seatCapacity;
 
+  private LocalDate deletedAt;
+
   public Venue(String name, String location, int seatCapacity) {
     this.name = name;
     this.location = location;
@@ -39,5 +42,13 @@ public class Venue extends BaseEntity {
     this.name = name;
     this.location = location;
     this.seatCapacity = seatCapacity;
+  }
+
+  public void softDelete() {
+    this.deletedAt = LocalDate.now();
+  }
+
+  public boolean isDeleted() {
+    return this.deletedAt != null;
   }
 }

--- a/src/main/java/org/example/siljeun/domain/venue/repository/VenueRepository.java
+++ b/src/main/java/org/example/siljeun/domain/venue/repository/VenueRepository.java
@@ -1,8 +1,13 @@
 package org.example.siljeun.domain.venue.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.example.siljeun.domain.venue.entity.Venue;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VenueRepository extends JpaRepository<Venue, Long> {
-  
+
+  List<Venue> findAllByDeletedAtIsNull();
+
+  Optional<Venue> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/example/siljeun/domain/venue/service/VenueServiceImpl.java
+++ b/src/main/java/org/example/siljeun/domain/venue/service/VenueServiceImpl.java
@@ -38,7 +38,14 @@ public class VenueServiceImpl implements VenueService {
 
   @Override
   public void deleteVenue(Long venueId) {
-    venueRepository.deleteById(venueId);
+    Venue venue = venueRepository.findById(venueId)
+        .orElseThrow(() -> new EntityNotFoundException("해당 공연장을 찾을 수 없습니다."));
+
+    if (venue.isDeleted()) {
+      throw new IllegalStateException("이미 삭제된 공연장입니다.");
+    }
+
+    venue.softDelete();
   }
 
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 공연장(Venue) 도메인에 **Soft Delete** 기능 도입
- 공연 등록/수정 시 **삭제된 공연장 접근 방지 처리**
- Redis 캐시에 저장되는 **일간/주간 인기 공연 키에 TTL 자동 설정**
- `concert:ranking`, `ranking:daily`, `ranking:weekly` 캐시에 모두 score 증가 처리

---

## 🛠️ 변경 사항

###  Venue 엔티티 (`Venue.java`)

- `deletedAt` 필드 (`LocalDate`) 추가
- `softDelete()` 메서드 추가 → 논리 삭제 처리
- `isDeleted()` 메서드 추가 → 삭제 여부 확인

###  VenueRepository

- `findByIdAndDeletedAtIsNull(Long id)` 메서드 추가
- `findAllByDeletedAtIsNull()` 메서드 추가

###  VenueServiceImpl

- 공연장 삭제 시 `deleteById()` → `softDelete()` 방식으로 변경
- 이미 삭제된 공연장 삭제 시 예외 발생 처리 추가

###  ConcertServiceImpl

- 공연 등록/수정 시 venue 조회를 `findByIdAndDeletedAtIsNull()`로 변경
- 공연 상세 조회 시 venue가 삭제되었으면 `IllegalStateException` 발생 처리

###  ConcertCacheService

- `increaseViewCount(concertId)` 호출 시:
  - `concert:ranking`, `ranking:daily`, `ranking:weekly` 모두에 score +1
  - `ensureTtl()` 메서드를 통해 각 ZSet 키에 TTL 적용
    - `ranking:daily`: 1일 TTL
    - `ranking:weekly`: 7일 TTL
- `ensureTtl(String key, Duration ttl)` 메서드 신규 추가:
  - `TTL 없음` 또는 `음수 값`일 경우만 TTL 설정

---



